### PR TITLE
Add /sessions command

### DIFF
--- a/remote.go
+++ b/remote.go
@@ -178,6 +178,12 @@ func (r *reply) readValue(v interface{}) error {
 	return json.Unmarshal(r.Value, v)
 }
 
+// An active session.
+type Session struct {
+	Id           string
+	Capabilities Capabilities
+}
+
 /* Create new remote client, this will also start a new session.
    capabilities - the desired capabilities, see http://goo.gl/SNlAk
    executor - the URL to the Selenim server
@@ -241,6 +247,14 @@ func (wd *remoteWebDriver) Status() (v *Status, err error) {
 	var r *reply
 	if r, err = wd.send("GET", wd.url("/status"), nil); err == nil {
 		err = r.readValue(&v)
+	}
+	return
+}
+
+func (wd *remoteWebDriver) Sessions() (sessions []Session, err error) {
+	var r *reply
+	if r, err = wd.send("GET", wd.url("/sessions"), nil); err == nil {
+		err = r.readValue(&sessions)
 	}
 	return
 }

--- a/remote_test.go
+++ b/remote_test.go
@@ -49,6 +49,20 @@ func TestStatus(t *testing.T) {
 	}
 }
 
+func TestSessions(t *testing.T) {
+	if *grid {
+		t.Skip()
+	}
+	t.Parallel()
+	wd := newRemote("TestSessions", t)
+	defer wd.Quit()
+
+	_, err := wd.Sessions()
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestNewSession(t *testing.T) {
 	t.Parallel()
 	if *runOnSauce {

--- a/selenium.go
+++ b/selenium.go
@@ -124,6 +124,9 @@ type WebDriver interface {
 	/* Status (info) on server */
 	Status() (*Status, error)
 
+	/* List of actions on the server. */
+	Sessions() ([]Session, error)
+
 	/* Start a new session, return session id */
 	NewSession() (string, error)
 


### PR DESCRIPTION
This adds a WebDriver method Sessions(), which returns an array of active server sessions according to the JsonWireProtocol command “/sessions”. A test for Sessions() is included in remote_test.go.

No existing code is modified, so nothing breaks when people update.