### PR TITLE
Fix import comment to fix failing in go 1.4

### DIFF
--- a/selenium.go
+++ b/selenium.go
@@ -1,4 +1,4 @@
-package selenium // import "sourcegraph.com/sourcegraph/go-selenium"
+package selenium /* import "sourcegraph.com/sourcegraph/go-selenium" */
 
 /* Element finding options */
 const (


### PR DESCRIPTION
Using go 1.4 'go get -u -a' logs the error message:

package github.com/sourcegraph/go-selenium: code in directory /Users/user/workspace/go/src/github.com/sourcegraph/go-selenium expects import "sourcegraph.com/sourcegraph/go-selenium"