### PR TITLE
Pageload timeout feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 go-selenium - Selenium WebDriver client for Go
 ==============================================
 
-[![status](https://sourcegraph.com/api/repos/sourcegraph.com/sourcegraph/go-selenium/badges/status.png)](https://sourcegraph.com/sourcegraph/go-selenium)
+[![status](https://sourcegraph.com/api/repos/github.com/carstn/go-selenium/badges/status.png)](https://github.com/carstn/go-selenium)
 
 go-selenium is a [Selenium](http://seleniumhq.org) WebDriver client for [Go](http://golang.org).
 
@@ -34,7 +34,7 @@ func ExampleFindElement() {
 	}
 	defer webDriver.Quit()
 
-	err = webDriver.Get("https://sourcegraph.com/sourcegraph/go-selenium")
+	err = webDriver.Get("https://github.com/carstn/go-selenium")
 	if err != nil {
 		fmt.Printf("Failed to load page: %s\n", err)
 		return
@@ -75,7 +75,7 @@ from the return values and instead calls `t.Fatalf` upon encountering an error. 
 package mytest
 
 import (
-  "sourcegraph.com/sourcegraph/go-selenium"
+  "github.com/carstn/go-selenium"
   "testing"
 )
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Note: the public API is experimental and subject to change until further notice.
 Usage
 =====
 
-Documentation: [go-selenium on Sourcegraph](https://sourcegraph.com/sourcegraph/go-selenium).
+Documentation: [go-selenium on Sourcegraph](https://godoc.org/github.com/carstn/go-selenium).
 
 Example: see example_test.go:
 
@@ -21,7 +21,7 @@ package selenium_test
 
 import (
 	"fmt"
-	"sourcegraph.com/sourcegraph/go-selenium"
+	"github.com/carstn/go-selenium"
 )
 
 func ExampleFindElement() {

--- a/example_test.go
+++ b/example_test.go
@@ -3,7 +3,7 @@ package selenium_test
 import (
 	"fmt"
 
-	"sourcegraph.com/sourcegraph/go-selenium"
+	"github.com/carstn/go-selenium"
 )
 
 func ExampleFindElement() {

--- a/example_test.go
+++ b/example_test.go
@@ -16,7 +16,7 @@ func ExampleFindElement() {
 	}
 	defer webDriver.Quit()
 
-	err = webDriver.Get("https://sourcegraph.com/sourcegraph/go-selenium")
+	err = webDriver.Get("https://github.com/carstn/go-selenium")
 	if err != nil {
 		fmt.Printf("Failed to load page: %s\n", err)
 		return

--- a/remote.go
+++ b/remote.go
@@ -15,11 +15,11 @@ import (
 	"log"
 	"net/http"
 	"net/http/httputil"
-	"os"
 	"strings"
 )
 
-var Log = log.New(os.Stderr, "[selenium] ", log.Ltime|log.Lmicroseconds)
+//var Log = log.New(os.Stderr, "[selenium] ", log.Ltime|log.Lmicroseconds)
+var Log = log.New(ioutil.Discard, "[selenium] ", log.Ltime|log.Lmicroseconds)
 var Trace bool
 
 /* Errors returned by Selenium server. */

--- a/remote.go
+++ b/remote.go
@@ -294,6 +294,10 @@ func (wd *remoteWebDriver) SetImplicitWaitTimeout(ms uint) error {
 	return wd.voidCommand("/session/%s/timeouts/implicit_wait", timeoutParam{ms})
 }
 
+func (wd *remoteWebDriver) SetPageLoadTimeout(ms uint) error {
+	return wd.voidCommand("/session/%s/timeouts/page_load", timeoutParam{ms})
+}
+
 func (wd *remoteWebDriver) AvailableEngines() ([]string, error) {
 	return wd.stringsCommand("/session/%s/ime/available_engines")
 }

--- a/selenium.go
+++ b/selenium.go
@@ -1,4 +1,4 @@
-package selenium // import "github.com/carstn/go-selenium"
+package selenium
 
 /* Element finding options */
 const (

--- a/selenium.go
+++ b/selenium.go
@@ -1,4 +1,4 @@
-package selenium // import "sourcegraph.com/sourcegraph/go-selenium"
+package selenium // import "github.com/carstn/go-selenium"
 
 /* Element finding options */
 const (

--- a/selenium.go
+++ b/selenium.go
@@ -136,6 +136,8 @@ type WebDriver interface {
 	SetAsyncScriptTimeout(ms uint) error
 	/* Set the amount of time, in milliseconds, the driver should wait when searching for elements. */
 	SetImplicitWaitTimeout(ms uint) error
+	/* Set the amount of time, in milliseconds, the driver should wait when loading a page. */
+	SetPageLoadTimeout(ms uint) error
 
 	// IME
 	/* List all available engines on the machine. */


### PR DESCRIPTION
An instance of WebDriver can now call `SetPageLoadTimeout(ms uint)
error` in order to set the “page load” timeout setting. It mimics the
SetImplicitWaitTimeout() function.