### PR TITLE
GetCookies fails to deserialize expiry when using chromedriver

### DIFF
--- a/remote_test.go
+++ b/remote_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 )
 
 var grid = flag.Bool("test.grid", false, "skip tests that fail on Selenium Grid")
@@ -354,6 +355,10 @@ func TestGetCookies(t *testing.T) {
 	if cookies[0].Name == "" {
 		t.Fatal("Empty cookie")
 	}
+
+	if cookies[0].Expiry != uint(cookieExpiry.Unix()) {
+		t.Fatalf("Bad expiry time: expected %v, got %v", cookieExpiry, cookies[0].Expiry)
+	}
 }
 
 func TestAddCookie(t *testing.T) {
@@ -550,6 +555,8 @@ var pages = map[string]string{
 	"/search": searchPage,
 }
 
+var cookieExpiry = time.Now().Add(1 * time.Hour).UTC()
+
 func handler(w http.ResponseWriter, r *http.Request) {
 	path := r.URL.Path
 	page, ok := pages[path]
@@ -566,8 +573,9 @@ func handler(w http.ResponseWriter, r *http.Request) {
 	for i := 0; i < 3; i++ {
 		name := fmt.Sprintf("cookie-%d", i)
 		value := fmt.Sprintf("value-%d", i)
-		http.SetCookie(w, &http.Cookie{Name: name, Value: value})
+		http.SetCookie(w, &http.Cookie{Name: name, Value: value, Expires: cookieExpiry})
 	}
+
 	fmt.Fprintf(w, page)
 }
 

--- a/selenium.go
+++ b/selenium.go
@@ -117,7 +117,7 @@ type Cookie struct {
 	Path   string `json:"path"`
 	Domain string `json:"domain"`
 	Secure bool   `json:"secure"`
-	Expiry uint   `json:"expiry"`
+	Expiry uint   `json:"-"`
 }
 
 type WebDriver interface {


### PR DESCRIPTION
Fixes #14

I ended up conserving the existing API. I added expiry to the tests, and it works on Chrome now. I don't have firefox installed, so you might want to double check it didn't break there.