### PR TITLE
Fixes TestNewSession on chromedriver

### DIFF
--- a/remote_test.go
+++ b/remote_test.go
@@ -68,7 +68,7 @@ func TestNewSession(t *testing.T) {
 	if *runOnSauce {
 		return
 	}
-	wd := &remoteWebDriver{capabilities: caps, executor: defaultExecutor}
+	wd := &remoteWebDriver{capabilities: caps, executor: *executor}
 	sid, err := wd.NewSession()
 	defer wd.Quit()
 


### PR DESCRIPTION
Ran into this one while working on #14. I changed it to use the executor that get's defined by the flag, which I think is correct? 