### PR TITLE
fix passing WebElement-type arguments to ExecuteScript

### DIFF
--- a/remote.go
+++ b/remote.go
@@ -584,6 +584,11 @@ func (wd *remoteWebDriver) execScript(script string, args []interface{}, suffix 
 	if args == nil {
 		args = []interface{}{}
 	}
+	for i, arg := range args {
+		if v, ok := arg.(*remoteWE); ok {
+			args[i] = &element{Element: v.id}
+		}
+	}
 	params := map[string]interface{}{
 		"script": script,
 		"args":   args,


### PR DESCRIPTION
Make it such that `WebElement` interfaces originating from this package can be
passed as arguments to `WebDriver.ExecuteScript` per section "10. Elements",
paragraph "When asked to serialize the element element" of the W3C WebDriver
specification (https://www.w3.org/TR/webdriver).