### PR TITLE
Screenshot() returning io.Reader instead of byte[]

### DIFF
--- a/remote.go
+++ b/remote.go
@@ -11,6 +11,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -625,7 +626,7 @@ func (wd *remoteWebDriver) ExecuteScriptAsync(script string, args []interface{})
 	return wd.execScript(script, args, "_async")
 }
 
-func (wd *remoteWebDriver) Screenshot() ([]byte, error) {
+func (wd *remoteWebDriver) Screenshot() (io.Reader, error) {
 	data, err := wd.stringCommand("/session/%s/screenshot")
 	if err != nil {
 		return nil, err
@@ -634,7 +635,7 @@ func (wd *remoteWebDriver) Screenshot() ([]byte, error) {
 	// Selenium returns base64 encoded image
 	buf := []byte(data)
 	decoder := base64.NewDecoder(base64.StdEncoding, bytes.NewBuffer(buf))
-	return ioutil.ReadAll(decoder)
+	return decoder, nil
 }
 
 func (wd *remoteWebDriver) T(t TestingT) WebDriverT {

--- a/remote_test.go
+++ b/remote_test.go
@@ -3,6 +3,7 @@ package selenium
 import (
 	"flag"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"strings"
 	"testing"
@@ -523,7 +524,12 @@ func TestScreenshot(t *testing.T) {
 	defer wd.Quit()
 
 	wd.Get(serverURL)
-	data := wd.Screenshot()
+	dataReader := wd.Screenshot()
+
+	data, err := ioutil.ReadAll(dataReader)
+	if err != nil {
+		t.Fatal("failed to read screenshot data")
+	}
 
 	if len(data) == 0 {
 		t.Fatal("Empty reply")

--- a/selenium.go
+++ b/selenium.go
@@ -1,5 +1,7 @@
 package selenium // import "sourcegraph.com/sourcegraph/go-selenium"
 
+import "io"
+
 /* Element finding options */
 const (
 	ById              = "id"
@@ -235,7 +237,7 @@ type WebDriver interface {
 	modifier can be one of ShiftKey, ControlKey, AltKey, MetaKey.
 	*/
 	SendModifier(modifier string, isDown bool) error
-	Screenshot() ([]byte, error)
+	Screenshot() (io.Reader, error)
 
 	// Alerts
 	/* Dismiss current alert. */

--- a/test_helpers.go
+++ b/test_helpers.go
@@ -2,6 +2,7 @@ package selenium
 
 import (
 	"fmt"
+	"io"
 	"path/filepath"
 	"runtime"
 	"strconv"
@@ -62,7 +63,7 @@ type WebDriverT interface {
 	ButtonUp()
 
 	SendModifier(modifier string, isDown bool)
-	Screenshot() []byte
+	Screenshot() io.Reader
 
 	DismissAlert()
 	AcceptAlert()
@@ -323,7 +324,7 @@ func (wt *webDriverT) SendModifier(modifier string, isDown bool) {
 	}
 }
 
-func (wt *webDriverT) Screenshot() (data []byte) {
+func (wt *webDriverT) Screenshot() (data io.Reader) {
 	var err error
 	if data, err = wt.d.Screenshot(); err != nil {
 		fatalf(wt.t, "Screenshot: %s", err)


### PR DESCRIPTION
It would be nice if `Screenshot()` would give user more control by returning `io.Reader` instead of `byte[]`.
User can always call `ioutil.ReadAll()` if needed.