### PR TITLE
Add support for context.Context automatic Quit()

### DIFF
--- a/selenium.go
+++ b/selenium.go
@@ -1,4 +1,5 @@
 package selenium // import "sourcegraph.com/sourcegraph/go-selenium"
+import "context"
 
 import "io"
 
@@ -123,6 +124,8 @@ type Cookie struct {
 }
 
 type WebDriver interface {
+	SetContext(context.Context)
+
 	/* Status (info) on server */
 	Status() (*Status, error)
 


### PR DESCRIPTION
It's annoying if you interrupt tests to have them leave a browser
window open.

You might have to wait a while before you can run your tests again.

This adds support for go 1.7's `context.Context`. It instruments all
requests, causing them to cancel the outgoing HTTP request to selenium
if the context is canceled.

In addition, it checks on entry and exit to a HTTP request if the
context is canceled, to ensure we notice rapidly.

If the context is canceled, `wd.Quit()` is called. For convenience, it's
made legal to call quit more than once, so that code which does:

```go
wd := makeWD()
defer wd.Quit()
```

Remains legal.

An example of use:

```go
var cancel func()
ctx, cancel = context.WithCancel(context.Background())
go func() {
	interrupt := make(chan os.Signal)
	signal.Notify(interrupt, os.Interrupt)
	<-interrupt
	log.Printf("Received interrupt.")
	cancel()
}()

wd := makeWD()
wd.SetContext(ctx)

wd.Get(...)
// ... etc, etc.
```

The net effect is that interrupting the tests now give `X failed:
canceled`, and the browser window quits.