### PR TITLE
Removing hard coded package URL

### DIFF
--- a/selenium.go
+++ b/selenium.go
@@ -1,4 +1,4 @@
-package selenium // import "sourcegraph.com/sourcegraph/go-selenium"
+package selenium
 import "context"
 
 import "io"


### PR DESCRIPTION
Fixes #29
If not it gives error on build as:
cant load package: package github.com/sourcegraph/go-selenium: code in
directory $GOPATH/src/github.com/sourcegraph/go-selenium expects import
"sourcegraph.com/sourcegraph/go-selenium"