### PR TITLE
Fix broken link to browser capabilities documentation

### DIFF
--- a/remote.go
+++ b/remote.go
@@ -1,6 +1,7 @@
 /* Remote Selenium client implementation.
 
-See http://code.google.com/p/selenium/wiki/JsonWireProtocol for wire protocol.
+See https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol for
+wire protocol.
 */
 
 package selenium

--- a/selenium.go
+++ b/selenium.go
@@ -82,7 +82,7 @@ const (
 )
 
 /* Browser capabilities, see
-http://code.google.com/p/selenium/wiki/JsonWireProtocol#Capabilities_JSON_Object
+https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol#capabilities-json-object
 */
 type Capabilities map[string]interface{}
 


### PR DESCRIPTION
The [previous link](http://code.google.com/p/selenium/wiki/JsonWireProtocol#Capabilities_JSON_Object) redirects to a message about the move from Google Code to GitHub.