### PR TITLE
Tweak selenium.Capabilities example

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ import (
 func ExampleFindElement() {
 	var webDriver selenium.WebDriver
 	var err error
-	caps := selenium.Capabilities(map[string]interface{}{"browserName": "firefox"})
+	caps := selenium.Capabilities{"browserName": "firefox"}
 	if webDriver, err = selenium.NewRemote(caps, "http://localhost:4444/wd/hub"); err != nil {
 		fmt.Printf("Failed to open session: %s\n", err)
 		return

--- a/example_test.go
+++ b/example_test.go
@@ -9,7 +9,7 @@ import (
 func ExampleFindElement() {
 	var webDriver selenium.WebDriver
 	var err error
-	caps := selenium.Capabilities(map[string]interface{}{"browserName": "firefox"})
+	caps := selenium.Capabilities{"browserName": "firefox"}
 	if webDriver, err = selenium.NewRemote(caps, "http://localhost:4444/wd/hub"); err != nil {
 		fmt.Printf("Failed to open session: %s\n", err)
 		return


### PR DESCRIPTION
`map[string]interface{}{"key": "value"}` casted to `selenium.Capabilities` is fairly verbose when we can instead use:

```go
selenium.Capabilities{"key": "value"}
```