### PR TITLE
Correct license info in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,4 +130,4 @@ Contributors
 License
 =======
 
-go-selenium is distributed under the Eclipse Public License.
+go-selenium is distributed under the MIT License.


### PR DESCRIPTION
[`LICENSE.txt`](https://github.com/sourcegraph/go-selenium/blob/master/LICENSE.txt) specifies the MIT License while the readme specifies the Eclipse Public License. I've updated the readme to reflect this.

Is the intention to stick with the original license or to *change* it to the EPL?