### PR TITLE
Remove use of ioutil package

### DIFF
--- a/remote.go
+++ b/remote.go
@@ -13,7 +13,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"net/http/httputil"
@@ -139,7 +138,7 @@ func (wd *remoteWebDriver) execute(method, url string, data []byte) (buf []byte,
 		}
 	}
 
-	buf, err = ioutil.ReadAll(res.Body)
+	buf, err = io.ReadAll(res.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/remote_test.go
+++ b/remote_test.go
@@ -3,7 +3,6 @@ package selenium
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"strings"
 	"testing"
@@ -526,7 +525,7 @@ func TestScreenshot(t *testing.T) {
 	wd.Get(serverURL)
 	dataReader := wd.Screenshot()
 
-	data, err := ioutil.ReadAll(dataReader)
+	data, err := io.ReadAll(dataReader)
 	if err != nil {
 		t.Fatal("failed to read screenshot data")
 	}

--- a/selenium.go
+++ b/selenium.go
@@ -1,7 +1,8 @@
 package selenium // import "sourcegraph.com/sourcegraph/go-selenium"
-import "context"
-
-import "io"
+import (
+	"context"
+	"io"
+)
 
 /* Element finding options */
 const (


### PR DESCRIPTION
Removes usage of the deprecated ioutil package as described [here](https://golang.org/doc/go1.16#ioutil)

[_Created by Sourcegraph batch change `rslade/deprecate-ioutil`._](https://k8s.sgdev.org/users/rslade/batch-changes/deprecate-ioutil)